### PR TITLE
Playbook fixes

### DIFF
--- a/content/meta/modules/ROOT/pages/overview/build.adoc
+++ b/content/meta/modules/ROOT/pages/overview/build.adoc
@@ -37,7 +37,7 @@ $ vale sync
 [.no-prose-lint]
 == Install node dependencies
 
-Before building the docs, specially the first time, it is recommended to install the dependencies used by antora and some of the extensions. To install those dependencies, run the following command in the `axoniq-library-site` folder.
+Before building the docs, especially the first time, it is recommended to install the dependencies used by Antora and some of the extensions. To install those dependencies, run the following command in the `axoniq-library-site` folder.
 
 [source,console]
 ---

--- a/content/meta/modules/ROOT/pages/overview/build.adoc
+++ b/content/meta/modules/ROOT/pages/overview/build.adoc
@@ -34,6 +34,17 @@ The prose linter uses rules from third parties distributed via https://vale.sh/h
 $ vale sync
 ----
 
+[.no-prose-lint]
+== Install node dependencies
+
+Before building the docs, specially the first time, it is recommended to install the dependencies used by antora and some of the extensions. To install those dependencies, run the following command in the `axoniq-library-site` folder.
+
+[source,console]
+---
+$ npm install
+---
+
+
 == Build with production configuration
 
 You can build AxonIQ Library locally with the production configuration to ensure you have all the tooling in place and properly configured. To do so, go to the `axoniq-library-site` folder and run the following command.

--- a/content/meta/modules/ROOT/pages/overview/build.adoc
+++ b/content/meta/modules/ROOT/pages/overview/build.adoc
@@ -43,6 +43,8 @@ You can build AxonIQ Library locally with the production configuration to ensure
 $ npx antora playbook.yaml
 ----
 
+IMPORTANT: As described in the https://docs.antora.org/antora/latest/install/install-antora/[instructions to install Antora], make sure you are running a *LTS version of Node.js*
+
 The above uses the `playbook.yaml`, where the locations of the content sources are remote Git repositories. Therefore the build may take a while as the site generator needs to fetch all remote repositories containing content sources.
 
 === Access to private repositories


### PR DESCRIPTION
Added the _source_code_links folder of AxonFramework to the exclusion list in the playbook-*.yaml files

Also added a reminder note in the "How to Build AxonIQ Library" to check the node version, as it was causing some errors  locally for me for not using a LTS version. And those errors are not pointing to the node version. Although that requirement is already stated on the antora install instructions, it may be ignored by people, like me, that have node in a different version, already installed.