### PR TITLE
Add old docs

### DIFF
--- a/playbook-dev-ui.yaml
+++ b/playbook-dev-ui.yaml
@@ -11,6 +11,9 @@ content:
   - url: ./localLinks/AxonFramework/          # include docs from Axon Framework repo
     start_paths: ['docs/*', '!docs/_*']       # from every folder in `docs` except those starting with underscore
 
+  - url: ./localLinks/axon-amqp/               # include docs from Axon AMQP Extension repo
+    start_paths: ['docs/*', '!docs/_*']        # from every folder in `docs` except those starting with underscore
+
   - url: ./localLinks/axon-server/             # include docs from Axon Server repo
     start_paths: ['docs/*', '!docs/_*']       # from every folder in `docs` except those starting with underscore
 #    branches: [master, 'axonserver-ee-20*']   # and from the specified branches

--- a/playbook-dev-ui.yaml
+++ b/playbook-dev-ui.yaml
@@ -11,7 +11,13 @@ content:
   - url: ./localLinks/AxonFramework/          # include docs from Axon Framework repo
     start_paths: ['docs/*', '!docs/_*']       # from every folder in `docs` except those starting with underscore
 
-  - url: ./localLinks/axon-amqp/               # include docs from Axon AMQP Extension repo
+  - url: ./localLinks/extension-amqp/          # include docs from Axon AMQP Extension repo
+    start_paths: ['docs/*', '!docs/_*']        # from every folder in `docs` except those starting with underscore
+
+  - url: ./localLinks/extension-jgroups/       # include docs from Axon JGroups Extension repo
+    start_paths: ['docs/*', '!docs/_*']        # from every folder in `docs` except those starting with underscore
+
+  - url: ./localLinks/extension-jobrunrpro/    # include docs from Axon JobRunr Pro Extension repo
     start_paths: ['docs/*', '!docs/_*']        # from every folder in `docs` except those starting with underscore
 
   - url: ./localLinks/axon-server/             # include docs from Axon Server repo

--- a/playbook-dev.yaml
+++ b/playbook-dev.yaml
@@ -18,6 +18,9 @@ content:
   - url: ./localLinks/extension-jgroups/       # include docs from Axon JGroups Extension repo
     start_paths: ['docs/*', '!docs/_*']        # from every folder in `docs` except those starting with underscore
 
+  - url: ./localLinks/extension-jobrunrpro/    # include docs from Axon JobRunr Pro Extension repo
+    start_paths: ['docs/*', '!docs/_*']        # from every folder in `docs` except those starting with underscore
+
   - url: ./localLinks/axon-server/             # include docs from Axon Server repo
     start_paths: ['docs/*', '!docs/_*']       # from every folder in `docs` except those starting with underscore
 # #    branches: [master, 'axonserver-ee-20*']   # and from the specified branches

--- a/playbook-dev.yaml
+++ b/playbook-dev.yaml
@@ -12,6 +12,12 @@ content:
     start_paths: ['docs/*', '!docs/_*', '!docs/reference/*']       # from every folder in `docs` except those starting with underscore
     branches: [feature/insert-af-reference-guide]
 
+  - url: ./localLinks/extension-amqp/          # include docs from Axon AMQP Extension repo
+    start_paths: ['docs/*', '!docs/_*']        # from every folder in `docs` except those starting with underscore
+
+  - url: ./localLinks/extension-jgroups/       # include docs from Axon JGroups Extension repo
+    start_paths: ['docs/*', '!docs/_*']        # from every folder in `docs` except those starting with underscore
+
   - url: ./localLinks/axon-server/             # include docs from Axon Server repo
     start_paths: ['docs/*', '!docs/_*']       # from every folder in `docs` except those starting with underscore
 # #    branches: [master, 'axonserver-ee-20*']   # and from the specified branches

--- a/playbook-dev.yaml
+++ b/playbook-dev.yaml
@@ -21,6 +21,9 @@ content:
   - url: ./localLinks/extension-jobrunrpro/    # include docs from Axon JobRunr Pro Extension repo
     start_paths: ['docs/*', '!docs/_*']        # from every folder in `docs` except those starting with underscore
 
+  - url: ./localLinks/extension-kafka/         # include docs from Axon Kafka Extension repo
+    start_paths: ['docs/*', '!docs/_*']        # from every folder in `docs` except those starting with underscore
+
   - url: ./localLinks/axon-server/             # include docs from Axon Server repo
     start_paths: ['docs/*', '!docs/_*']       # from every folder in `docs` except those starting with underscore
 # #    branches: [master, 'axonserver-ee-20*']   # and from the specified branches

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -15,6 +15,9 @@ content:
   - url: https://github.com/AxonFramework/AxonFramework.git   # include docs from Axon Framework repo
     start_paths: ['docs/*', '!docs/_*']                       # from every folder in `docs` except those starting with underscore
 
+  - url: https://github.com/AxonFramework/extension-amqp.git   # include docs from Image generation for Axon AMQP Extension repo 
+    start_paths: ['docs/*', '!docs/_*']                        # from every folder in `docs` except those starting with underscore
+
   - url: https://github.com/AxonIQ/axon-server.git            # include docs from Axon Server repo
     start_paths: ['docs/*', '!docs/_*']                       # from every folder in `docs` except those starting with underscore
 #    branches: [master, 'axonserver-ee-20*']                   # and from the specified branches

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -15,8 +15,11 @@ content:
   - url: https://github.com/AxonFramework/AxonFramework.git   # include docs from Axon Framework repo
     start_paths: ['docs/*', '!docs/_*']                       # from every folder in `docs` except those starting with underscore
 
-  - url: https://github.com/AxonFramework/extension-amqp.git   # include docs from Image generation for Axon AMQP Extension repo 
+  - url: https://github.com/AxonFramework/extension-amqp.git   # include docs for Axon AMQP Extension repo 
     start_paths: ['docs/*', '!docs/_*']                        # from every folder in `docs` except those starting with underscore
+
+  - url: https://github.com/AxonFramework/extension-jgroups.git  # include docs for Axon JGroups Extension repo 
+    start_paths: ['docs/*', '!docs/_*']                          # from every folder in `docs` except those starting with underscore
 
   - url: https://github.com/AxonIQ/axon-server.git            # include docs from Axon Server repo
     start_paths: ['docs/*', '!docs/_*']                       # from every folder in `docs` except those starting with underscore

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -24,6 +24,9 @@ content:
   - url: https://github.com/AxonFramework/extension-jobrunrpro.git  # include docs for Axon JGroups Extension repo 
     start_paths: ['docs/*', '!docs/_*']                          # from every folder in `docs` except those starting with underscorej
 
+  - url: https://github.com/AxonFramework/extension-kafka.git  # include docs for Axon JGroups Extension repo 
+    start_paths: ['docs/*', '!docs/_*']                          # from every folder in `docs` except those starting with underscorej
+
   - url: https://github.com/AxonIQ/axon-server.git            # include docs from Axon Server repo
     start_paths: ['docs/*', '!docs/_*']                       # from every folder in `docs` except those starting with underscore
 #    branches: [master, 'axonserver-ee-20*']                   # and from the specified branches

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -21,6 +21,9 @@ content:
   - url: https://github.com/AxonFramework/extension-jgroups.git  # include docs for Axon JGroups Extension repo 
     start_paths: ['docs/*', '!docs/_*']                          # from every folder in `docs` except those starting with underscore
 
+  - url: https://github.com/AxonFramework/extension-jobrunrpro.git  # include docs for Axon JGroups Extension repo 
+    start_paths: ['docs/*', '!docs/_*']                          # from every folder in `docs` except those starting with underscorej
+
   - url: https://github.com/AxonIQ/axon-server.git            # include docs from Axon Server repo
     start_paths: ['docs/*', '!docs/_*']                       # from every folder in `docs` except those starting with underscore
 #    branches: [master, 'axonserver-ee-20*']                   # and from the specified branches


### PR DESCRIPTION
Add to docs source lists the following repos:
- `extension-amqp`
- `extension-jgroups`
- `extension-jobrunrpro`
- `extension-kafka`