### PR TITLE
Renamed Library to Documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,11 +1,11 @@
-= AxonIQ Library
+= AxonIQ Documentation
 
-This repository contains the code for the https://library.axoniq.io[AxonIQ Library site].
+This repository contains the code for the https://docs.axoniq.io[AxonIQ Documentation site].
 
-The https://library.axoniq.io/meta[contribution guide] contains information about the intention, design consideration, structure, build process, etc. Please refer to it if you would like to contribute.
+The https://docs.axoniq.io/meta[contribution guide] contains information about the intention, design consideration, structure, build process, etc. Please refer to it if you would like to contribute.
 
 Some notable resources:
 
-* https://library.axoniq.io/meta/design/doc-system.html[Explanation of the documentation system]
-* https://library.axoniq.io/meta/overview/build.html[Instructions how to build the library]
-* https://library.axoniq.io/meta/reference/improvements.html[List of pages needing improvements]
+* https://docs.axoniq.io/meta/design/doc-system.html[Explanation of the documentation system]
+* https://docs.axoniq.io/meta/overview/build.html[Instructions how to build the documentation]
+* https://docs.axoniq.io/meta/reference/improvements.html[List of pages needing improvements]

--- a/content/contribution_guide/modules/ROOT/pages/design/doc-system.adoc
+++ b/content/contribution_guide/modules/ROOT/pages/design/doc-system.adoc
@@ -1,6 +1,6 @@
 = Diataxis System
 
-AxonIQ Library closely follows the https://documentation.divio.com/[diataxis system], where all materials fall into one of the following groups: tutorials, how-to guides, documentation, and explanations. The site linked above provides a concise yet complete description and some examples.
+AxonIQ Documentation closely follows the https://documentation.divio.com/[diataxis system], where all materials fall into one of the following groups: tutorials, how-to guides, documentation, and explanations. The site linked above provides a concise yet complete description and some examples.
 
 == Four types of information
 
@@ -41,9 +41,9 @@ The following table _(copied from the website linked above)_ summarizes how thos
 | an article on culinary social history
 |===
 
-== Applying the system in AxonIQ Library
+== Applying the system in AxonIQ Documentation
 
-The AxonIQ Library contains three of the four content types: tutorials, how-to guides, and documentation. The fourth type, explanations, is embedded withtin the other three. 
+The AxonIQ Documentation contains three of the four content types: tutorials, how-to guides, and reference documentation. The fourth type, explanations, is embedded within the other three.
 
 
 === Tutorials
@@ -52,7 +52,7 @@ These materials take the reader by the hand and help them complete a project of 
 
 The following are some examples of content that you should write as tutorials.
 
-Building a Giftcard application:: Walks the reader through creating a somewhat simple application.
+Building a Gift Card application:: Walks the reader through creating a somewhat simple application.
 Axon Synapse quick start guide:: Walks the reader through the basics of using Axon Synapse
 Axon Server installation guide:: Basic instructions on how to run Axon Server on-premises, in Docker, and on the Cloud.
 

--- a/content/contribution_guide/modules/ROOT/pages/overview/build.adoc
+++ b/content/contribution_guide/modules/ROOT/pages/overview/build.adoc
@@ -1,6 +1,6 @@
-= Build AxonIQ Library
+= Build AxonIQ Documentation
 
-Below are the steps to aggregate all content from all sources and produce the final static website for AxonIQ Library.
+Below are the steps to aggregate all content from all sources and produce the final static website for AxonIQ Documentation.
 
 == Install required tools
 
@@ -47,7 +47,7 @@ $ npm install
 
 == Build with production configuration
 
-You can build AxonIQ Library locally with the production configuration to ensure you have all the tooling in place and properly configured. To do so, go to the `axoniq-library-site` folder and run the following command.
+You can build AxonIQ Documentation locally with the production configuration to ensure you have all the tooling in place and properly configured. To do so, go to the `axoniq-library-site` folder and run the following command.
 
 [source,console]
 ----
@@ -60,7 +60,7 @@ The above uses the `playbook.yaml`, where the locations of the content sources a
 
 === Access to private repositories
 
-Some of the content sources are private repositories that need authentication. You likely only have access to those if you are an AxonIQ employee or a trusted collaborator. If you aren't, you can still build most of the AxonIQ Library locally by making a copy of `playbook.yaml` and removing all the private content sources.
+Some of the content sources are private repositories that need authentication. You likely only have access to those if you are an AxonIQ employee or a trusted collaborator. If you aren't, you can still build most of the AxonIQ Documentation locally by making a copy of `playbook.yaml` and removing all the private content sources.
 
 If you are a member of the https://github.com/AxonIQ[AxonIQ Organization on GitHub], you must grant the build tool access to private repositories. To do so, you must create a Personal Access Token (PAT).
 
@@ -79,7 +79,7 @@ https://<USER_NAME>:<ACCEESS_TOKEN>@github.com
 ----
 
 Replace `<USER_NAME>` with your user name and `<ACCEESS_TOKEN>` with the full PAT you created __(starting with `github_pat_`)__.
-With that in place, you can fetch content from private repositories and build the AxonIQ Library locally from the production playbook.
+With that in place, you can fetch content from private repositories and build the AxonIQ Documentation locally from the production playbook.
 
 TIP: For alternative ways to configure access to content sources, check Antora's https://docs.antora.org/antora/latest/playbook/private-repository-auth/[Private Repository Authentication] page
 
@@ -134,7 +134,7 @@ CAUTION: When you use a custom playbook outside version control, you must monito
 
 === Build
 
-To build AxonIQ Library locally with the development configuration, go to the `axoniq-library-site` folder and run Antora with the desired playbook.
+To build AxonIQ Documentation locally with the development configuration, go to the `axoniq-library-site` folder and run Antora with the desired playbook.
 
 [source,console]
 ----
@@ -144,26 +144,26 @@ $ npx antora playbook-dev.yaml
 The above uses the `playbook-dev.yaml`. You can, of course, use `my-playbook.yaml` or any other instead.
 
 
-== Run AxonIQ Library locally
+== Run AxonIQ Documentation locally
 
 Antora generates a static site in `axoniq-library-site/build/site` folder. It doesn't have a web server to run the site on `localhost`. You may access it from your browser via the `file://` protocol, but some links may not work. You must have a web server running on your machine to access the site on a URL like `http://localhost:8080`. You can use any of the popular solutions available on your operating system.
 
 You can also start a simple web server from the `axoniq-library-site/build/site` folder in several different ways. Below are some examples.
 
-.Using Python to serve AxonIQ Library on `localhost:8080`
+.Using Python to serve AxonIQ Documentation on `localhost:8080`
 [source, console]
 ----
 python3 -m http.server 8080
 ----
 
-.Using NodeJS to serve AxonIQ Library on `localhost:8080`
+.Using NodeJS to serve AxonIQ Documentation on `localhost:8080`
 [source, console]
 ----
 npm install -g http-server
 http-server -p 8080
 ----
 
-.Using PHP to serve AxonIQ Library on `localhost:8080`
+.Using PHP to serve AxonIQ Documentation on `localhost:8080`
 [source, console]
 ----
 php -S localhost:8080

--- a/content/contribution_guide/modules/ROOT/pages/overview/content-sources.adoc
+++ b/content/contribution_guide/modules/ROOT/pages/overview/content-sources.adoc
@@ -2,7 +2,7 @@
 
 Content sources are the locations where the site builder finds the content to include in the website. Please refer to https://docs.antora.org/antora/latest/organize-content-files/[Antora's documentation] for more information.
 
-== AxonIQ Library convention
+== AxonIQ Documentation convention
 
 Before adding new ones or making any changes to existing content sources, please take time to understand the convention you need to comply with.
 
@@ -18,7 +18,7 @@ The https://github.com/AxonIQ/axoniq-library-site[documentation website reposito
 
 === Project-specific content sources
 
-Each project manages its own set of content sources. By convention, the location for those is the `docs` folder in the root of the three. The exception is the `docs/_playbook` folder which contains the playbooks to build the project's documentation independently of AxonIQ Library.
+Each project manages its own set of content sources. By convention, the location for those is the `docs` folder in the root of the three. The exception is the `docs/_playbook` folder which contains the playbooks to build the project's documentation independently of the AxonIQ Documentation platform.
 
 For every such project, there is a respective entry in the playbooks. The example below shows the record for Axon Framework in `playbook-dev.yaml`.
 
@@ -69,7 +69,7 @@ As generic content sources are already configured in the website project, adding
 
 === Adding a project content source
 
-If AxonIQ Library's playbook already contains an entry for the project, the rule is identical to the one for generic content sources. Create a new folder in the project's `docs` folder, recreate the expected folder structure, configure the `antora.yml` file accordingly, and start adding content.
+If AxonIQ Documentation's playbook already contains an entry for the project, the rule is identical to the one for generic content sources. Create a new folder in the project's `docs` folder, recreate the expected folder structure, configure the `antora.yml` file accordingly, and start adding content.
 
 ==== Configuring new project
 

--- a/content/contribution_guide/modules/ROOT/pages/overview/platform.adoc
+++ b/content/contribution_guide/modules/ROOT/pages/overview/platform.adoc
@@ -2,11 +2,11 @@
 :page-needs-improvement: stub
 :page-needs-stub: This document is a stub. Please expand it with relevant details.
 
-From technical perspective, AxonIQ Library is a somewhat complex content aggregator. While most content editors usually don't need to deal with that level of complexity, it helps to understand and familiarize with the tools used to build the final product.
+From technical perspective, the AxonIQ Documentation platform is a content aggregator. While most content editors usually don't need to deal with that level of complexity, it helps to understand and familiarize with the tools used to build the final product.
 
 == The main platform
 
-This project uses https://antora.org/[Antora] to aggregate content from many different sources and display it on the AxonIQ Library pages. Please refer to https://docs.antora.org[Antora's documentation] for more information.
+This project uses https://antora.org/[Antora] to aggregate content from many different sources and display it on the AxonIQ Documentation pages. Please refer to https://docs.antora.org[Antora's documentation] for more information.
 
 == The content format
 

--- a/content/legacy_docs_af/modules/ROOT/pages/index.adoc
+++ b/content/legacy_docs_af/modules/ROOT/pages/index.adoc
@@ -1,3 +1,3 @@
 = Legacy Axon Framework Documentation
 
-NOTE: The Axon Library contain documentation for Axon Framework 4.8 onwards. The menu on the left links to respective documentations for previous versions.
+NOTE: The Axon Documentation contain documentation for Axon Framework 4.8 onwards. The menu on the left links to respective documentations for previous versions.

--- a/content/legacy_docs_as/modules/ROOT/pages/index.adoc
+++ b/content/legacy_docs_as/modules/ROOT/pages/index.adoc
@@ -1,3 +1,3 @@
 = Legacy Axon Server Documentation
 
-NOTE: The Axon Library contain documentation for Axon Server 4.8 onwards. The menu on the left links to respective documentations for previous versions.
+NOTE: The Axon Documentation contain documentation for Axon Server 4.8 onwards. The menu on the left links to respective documentations for previous versions.

--- a/extensions/banner.js
+++ b/extensions/banner.js
@@ -2,7 +2,7 @@ var figlet = require('figlet');
 
 module.exports.register = () => {
 
-    figlet('AxonIQ Library', {font: 'Soft'}, function(err, data) {
+    figlet('AxonIQ Documentation', {font: 'Soft'}, function(err, data) {
         if (err) {
             console.log('Something went wrong while printing the banner...');
             console.dir(err);

--- a/extensions/build_time.js
+++ b/extensions/build_time.js
@@ -1,9 +1,9 @@
 module.exports.register = function () {
     this
         .on('contextStarted', () => {
-            console.time('AxonIQ Library built in')
+            console.time('AxonIQ Documentation built in')
         })
         .on('contextClosed', () => {
-            console.timeEnd('AxonIQ Library built in')
+            console.timeEnd('AxonIQ Documentation built in')
         })
 }

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -1,6 +1,6 @@
 site:
   title: Docs
-  url: https://library.axoniq.io
+  url: https://docs.axoniq.io
   start_page: home::index.adoc
   keys:
     google_tag_manager: 'GTM-5QD58ZB'


### PR DESCRIPTION
Also changed the canonical url to docs.axoniq.io