### PR TITLE
Replace trailing `.html` for `/` and add "latest" symlink

### DIFF
--- a/playbook.yaml
+++ b/playbook.yaml
@@ -6,6 +6,10 @@ site:
     google_tag_manager: 'GTM-5QD58ZB'
     # google_analytics: 'G-Z9N4KWZGQV'
 
+urls:
+  html_extension_style: indexify
+  latest_version_segment: latest
+
 content:
   sources:
   - url: .


### PR DESCRIPTION
This pull request sets two properties on the `playbook.yaml`, which have the following effect:

- `html_extension_style: indexify` - This setting replaces the trailing `.html` for a `/` in all our URLs for docs.axoniq.io. For specifics on this setting, check the documentation [here](https://docs.antora.org/antora/latest/playbook/urls-html-extension-style/).
- `latest_version_segment: latest` - This setting ensures that the last version gets a symbolic link, replacing the [version segment](https://docs.antora.org/antora/latest/how-antora-builds-urls/#version) in the URL. For those curious, Antora orders the component versions as per [this](https://docs.antora.org/antora/latest/how-component-versions-are-sorted/#version-sorting-rules) strategy. For specifics on this setting, check the documentation [here](https://docs.antora.org/antora/latest/playbook/urls-latest-version-segment/).