### PR TITLE
Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+version: 2
+
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: "sunday"
+  open-pull-requests-limit: 5
+  labels:
+    - "Type: Dependency Upgrade"
+    - "Priority 1: Must"
+  reviewers:
+    - "BraininaBowl"
+    - "bruceaxoniq"
+    - "CodeDrivenMitch"
+    - "smcvb"
+    - "trimoq"
+  groups:
+    github-dependencies:
+      update-types:
+        - "patch"
+        - "minor"
+        - "major"
+
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: "sunday"
+  open-pull-requests-limit: 5
+  labels:
+    - "Type: Dependency Upgrade"
+    - "Priority 1: Must"
+  reviewers:
+    - "BraininaBowl"
+    - "bruceaxoniq"
+    - "CodeDrivenMitch"
+    - "smcvb"
+    - "trimoq"
+  groups:
+    maven-dependencies:
+      update-types:
+        - "patch"
+        - "minor"
+        - "major"


### PR DESCRIPTION
This pull request adds a dedicated dependabot configuration.
By doing so, we streamline how dependabot constructs pull requests for the AxonIQ Docs.

The ecosystems I've let dependabot check, are the `github-actions` and `npm`, for which it will create a single grouped pull request per ecosystems every Sunday **if** there are versions to upgrade.

I have added @BraininaBowl, @bruceaxoniq, @CodeDrivenMitch, myself, and @trimoq to this, as @SaraTorrey is contacting us to further the AxonIQ Docs.
If either of you **really** doesn't want to be bothered about this (in most cases) auto-mergable PRs, just let me know.