### PR TITLE
Add Kroki with mermaid support

### DIFF
--- a/.github/workflows/check_pr.yml
+++ b/.github/workflows/check_pr.yml
@@ -22,6 +22,8 @@ jobs:
         sudo tar -xvzf vale_${VALE_VERSION}_Linux_64-bit.tar.gz -C /usr/local/bin vale
     - name: Install Dependencies
       run: npm install
+    - name: Start Kroki
+      uses: hoverkraft-tech/compose-action@v2.0.2
     - name: Generate Site
       run: |
         export GIT_CREDENTIALS='https://axoniq-devops:${{ secrets.LIBRARY_DEVBOT_TOKEN }}@github.com'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,8 @@ jobs:
       run: |
         wget https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz
         sudo tar -xvzf vale_${VALE_VERSION}_Linux_64-bit.tar.gz -C /usr/local/bin vale
+    - name: Start Kroki
+      uses: hoverkraft-tech/compose-action@v2.0.2
     - name: Generate Site
       run: |
         export GIT_CREDENTIALS='https://axoniq-devops:${{ secrets.LIBRARY_DEVBOT_TOKEN }}@github.com'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: "3"
+services:
+  core:
+    image: yuzutech/kroki
+    environment:
+      - KROKI_MERMAID_HOST=mermaid
+      - KROKI_BPMN_HOST=bpmn
+      - KROKI_EXCALIDRAW_HOST=excalidraw
+    ports:
+      - "8000:8000"
+  mermaid:
+    image: yuzutech/kroki-mermaid
+    ports:
+      - "8002:8002"
+  bpmn:
+    image: yuzutech/kroki-bpmn
+    ports:
+      - "8003:8003"
+  excalidraw:
+    image: yuzutech/kroki-excalidraw
+    ports:
+      - "8004:8004"

--- a/playbook-dev.yaml
+++ b/playbook-dev.yaml
@@ -12,9 +12,7 @@ content:
   - url: .
     start_paths: content/*
 
-  - url: ./localLinks/AxonFramework-main/          # include docs from Axon Framework repo
-    start_paths: ['docs/*', '!docs/_*', '!docs/reference/*']
-  - url: ./localLinks/AxonFramework-latest/          # include docs from Axon Framework repo
+  - url: ./localLinks/AxonFramework/          # include docs from Axon Framework repo
     start_paths: ['docs/*', '!docs/_*', '!docs/reference/*']       # from every folder in `docs` except those starting with underscore
 
   - url: ./localLinks/extension-amqp/          # include docs from Axon AMQP Extension repo
@@ -66,9 +64,6 @@ content:
     start_paths: ['docs/*', '!docs/_*']       # from every folder in `docs` except those starting with underscore
   #   branches: [master, docs]
 
-  - url: ./localLinks/giftcard-demo/          # include docs from Gift Card Demo repo
-    start_paths: ['docs/*', '!docs/_*']       # from every folder in `docs` except those starting with underscore
-
   - url: ./localLinks/bike-rental-quick-start/ # include docs from BikeRental Demo app
     start_paths: ['docs/*', '!docs/_*']        # from every folder in `docs` except those starting with underscore
 
@@ -81,7 +76,8 @@ asciidoc:
   attributes:
     experimental: true
     page-pagination: true
-    kroki-fetch-diagram: false
+    kroki-server-url: http://localhost:8000
+    kroki-fetch-diagram: true
   extensions:
   - asciidoctor-kroki
   - '@asciidoctor/tabs'

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -88,6 +88,7 @@ asciidoc:
   attributes:
     experimental: true
     page-pagination: true
+    kroki-server-url: http://localhost:8000
     kroki-fetch-diagram: true
   extensions:
   - asciidoctor-kroki


### PR DESCRIPTION
Adds a docker container and the necesary configuration at build to generate images locally for Mermaid or any other visual format.

It will support all the following formats:
/actdiag
/blockdiag
/bytefield
/c4plantuml
/d2
/ditaa
/erd
/graphviz
/dot
/nomnoml
/nwdiag
/packetdiag
/pikchr
/plantuml
/rackdiag
/seqdiag
/structurizr
/svgbob
/symbolator
/umlet
/vega
/vegalite
/wavedrom
/wireviz
/mermaid
/excalidraw
/bpmn