### PR TITLE
Add AxoniqFramework documentation source

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   core:
     image: yuzutech/kroki

--- a/localLinks/update.sh
+++ b/localLinks/update.sh
@@ -14,7 +14,8 @@ cloneOrPullMaster () {
 }
 
 # Axon Framework has two branches: master and 4.10.x
-cloneOrPullMaster "AxonFramework" "https://github.com/AxonFramework/AxonFramework.git" "axon-4.11.x"
+cloneOrPullMaster "AxonFramework" "https://github.com/AxonIQ/AxonFramework.git" "main"
+cloneOrPullMaster "AxoniqFramework" "https://github.com/AxonIQ/axoniq-framework.git" "main"
 cloneOrPullMaster "extension-amqp" "https://github.com/AxonFramework/extension-amqp.git" "axon-amqp-4.11.x"
 cloneOrPullMaster "extension-jgroups" "https://github.com/AxonFramework/extension-jgroups.git" "axon-jgroups-4.11.x"
 cloneOrPullMaster "extension-jobrunrpro" "https://github.com/AxonFramework/extension-jobrunrpro.git" "axon-jobrunrpro-4.11.x"
@@ -31,5 +32,6 @@ cloneOrPullMaster "axon-server-image-build" "https://github.com/AxonIQ/axon-serv
 cloneOrPullMaster "axon-synapse" "https://github.com/AxonIQ/axon-synapse.git" "synapse-0.11"
 cloneOrPullMaster "axoniq-platform" "https://github.com/AxonIQ/axoniq-platform.git" "main"
 cloneOrPullMaster "bike-rental-quick-start" "https://github.com/AxonIQ/bike-rental-quick-start.git" "main"
+cloneOrPullMaster "axoniq-playbook" "https://github.com/AxonIQ/axoniq-playbook.git" "main"
 
 echo "You should be up-to-date now!"

--- a/package-lock.json
+++ b/package-lock.json
@@ -417,7 +417,6 @@
       "resolved": "https://registry.npmjs.org/@asciidoctor/opal-runtime/-/opal-runtime-3.0.1.tgz",
       "integrity": "sha512-iW7ACahOG0zZft4A/4CqDcc7JX+fWRNjV5tFAVkNCzwZD+EnFolPaUOPYt8jzadc0+Bgd80cQTtRMQnaaV1kkg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "glob": "8.1.0",
         "unxhr": "1.2.0"
@@ -2148,7 +2147,6 @@
       "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
       "deprecated": "Glob versions prior to v9 are no longer supported",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -2888,7 +2886,6 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
       "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
@@ -3491,6 +3488,7 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }

--- a/playbook-dev-ui.yaml
+++ b/playbook-dev-ui.yaml
@@ -45,25 +45,26 @@ content:
     start_paths: ['docs/*', '!docs/_*']        # from every folder in `docs` except those starting with underscore
 
   - url: ./localLinks/axon-server/             # include docs from Axon Server repo
-    start_paths: ['docs/*', '!docs/_*']       # from every folder in `docs` except those starting with underscore
-#    branches: [master, 'axonserver-ee-20*']   # and from the specified branches
+    start_paths: ['docs/*', '!docs/_*', '!docs/as-fundamentals-tutorial']       # from every folder in `docs` except those starting with underscore
+    # branches: [master, 'axonserver-ee-20*']   # and from the specified branches
+
+  - url: ./localLinks/axon-server-image-build/ # include docs from Image generation for Axon Server repo (which contiains docs about Axon Server GCP marketplace)
+    start_paths: ['docs/*', '!docs/_*']        # from every folder in `docs` except those starting with underscore
+    # branches: [master, 'axonserver-ee-20*'] # and from the specified branches
 
   - url: ./localLinks/axon-synapse/            # include docs from Axon Synapse repo
     start_paths: ['docs/*', '!docs/_*']       # from every folder in `docs` except those starting with underscore
-  #   branches: [development, 'synapse-*']      # and from the specified branches
+    # branches: [development, 'synapse-*']      # and from the specified branches
 
   - url: ./localLinks/axoniq-platform/           # include docs from AxonIQ Console
     start_paths: ['docs/*', '!docs/_*']       # from every folder in `docs` except those starting with underscore
-  #   branches: [master, docs]
+    # branches: [master, docs]
 
   - url: ./localLinks/bike-rental-quick-start/ # include docs from BikeRental Demo app
     start_paths: ['docs/*', '!docs/_*']        # from every folder in `docs` except those starting with underscore
 
-
-  # - url: .
-  #   start_paths: external_repos/axon_server/docs/*
-  # - url: .
-  #   start_paths: external_repos/axoniq_cloud/docs/*
+  - url: ./localLinks/axoniq-playbook/ # include docs from BikeRental Demo app
+    start_paths: [ 'docs/*', '!docs/_*' ]        # from every folder in `docs` except those starting with underscore
 
 asciidoc:
   attributes:

--- a/playbook-dev-ui.yaml
+++ b/playbook-dev-ui.yaml
@@ -9,7 +9,10 @@ content:
     start_paths: content/*
 
   - url: ./localLinks/AxonFramework/          # include docs from Axon Framework repo
-    start_paths: ['docs/*', '!docs/_*']       # from every folder in `docs` except those starting with underscore
+    start_paths: ['docs/*', '!docs/_*', '!docs/reference/*']       # from every folder in `docs` except those starting with underscore
+
+  - url: ./localLinks/AxoniqFramework/          # include docs from Axon Framework repo
+    start_paths: [ 'docs/*', '!docs/_*', '!docs/reference/*' ]       # from every folder in `docs` except those starting with underscore
 
   - url: ./localLinks/extension-amqp/          # include docs from Axon AMQP Extension repo
     start_paths: ['docs/*', '!docs/_*']        # from every folder in `docs` except those starting with underscore
@@ -71,6 +74,7 @@ asciidoc:
     experimental: true
     page-pagination: true
     kroki-fetch-diagram: false
+    advanced-framework: true
   extensions:
   - asciidoctor-kroki
   - '@asciidoctor/tabs'

--- a/playbook-dev.yaml
+++ b/playbook-dev.yaml
@@ -50,27 +50,25 @@ content:
 
   - url: ./localLinks/axon-server/             # include docs from Axon Server repo
     start_paths: ['docs/*', '!docs/_*', '!docs/as-fundamentals-tutorial']       # from every folder in `docs` except those starting with underscore
-# #    branches: [master, 'axonserver-ee-20*']   # and from the specified branches
+    # branches: [master, 'axonserver-ee-20*']   # and from the specified branches
 
   - url: ./localLinks/axon-server-image-build/ # include docs from Image generation for Axon Server repo (which contiains docs about Axon Server GCP marketplace)
     start_paths: ['docs/*', '!docs/_*']        # from every folder in `docs` except those starting with underscore
-# #    branches: [master, 'axonserver-ee-20*'] # and from the specified branches
+    # branches: [master, 'axonserver-ee-20*'] # and from the specified branches
 
   - url: ./localLinks/axon-synapse/            # include docs from Axon Synapse repo
     start_paths: ['docs/*', '!docs/_*']       # from every folder in `docs` except those starting with underscore
-  #   branches: [development, 'synapse-*']      # and from the specified branches
+    # branches: [development, 'synapse-*']      # and from the specified branches
 
   - url: ./localLinks/axoniq-platform/           # include docs from AxonIQ Console
     start_paths: ['docs/*', '!docs/_*']       # from every folder in `docs` except those starting with underscore
-  #   branches: [master, docs]
+    # branches: [master, docs]
 
   - url: ./localLinks/bike-rental-quick-start/ # include docs from BikeRental Demo app
     start_paths: ['docs/*', '!docs/_*']        # from every folder in `docs` except those starting with underscore
 
-  # - url: .
-  #   start_paths: external_repos/axon_server/docs/*
-  # - url: .
-  #   start_paths: external_repos/axoniq_cloud/docs/*
+  - url: ./localLinks/axoniq-playbook/ # include docs from BikeRental Demo app
+    start_paths: [ 'docs/*', '!docs/_*' ]        # from every folder in `docs` except those starting with underscore
 
 asciidoc:
   attributes:

--- a/playbook-dev.yaml
+++ b/playbook-dev.yaml
@@ -15,6 +15,9 @@ content:
   - url: ./localLinks/AxonFramework/          # include docs from Axon Framework repo
     start_paths: ['docs/*', '!docs/_*', '!docs/reference/*']       # from every folder in `docs` except those starting with underscore
 
+  - url: ./localLinks/AxoniqFramework/          # include docs from Axon Framework repo
+    start_paths: [ 'docs/*', '!docs/_*', '!docs/reference/*' ]       # from every folder in `docs` except those starting with underscore
+
   - url: ./localLinks/extension-amqp/          # include docs from Axon AMQP Extension repo
     start_paths: ['docs/*', '!docs/_*']        # from every folder in `docs` except those starting with underscore
 
@@ -76,6 +79,7 @@ asciidoc:
     page-pagination: true
     kroki-server-url: http://localhost:8000
     kroki-fetch-diagram: true
+    advanced-framework: true
   extensions:
   - asciidoctor-kroki
   - '@asciidoctor/tabs'

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -71,7 +71,6 @@ content:
     start_paths: ['docs/*', '!docs/_*']                        # from every folder in `docs` except those starting with underscore
 #    branches: [main]                                          # and from the specified branches
 
-
   - url: https://github.com/AxonIQ/axon-synapse.git           # include docs from Axon Synapse repo
     start_paths: ['docs/*', '!docs/_*']                       # from every folder in `docs` except those starting with underscore
     branches: ['synapse-*']                           # and from the specified branches
@@ -83,7 +82,7 @@ content:
   - url: https://github.com/AxonIQ/bike-rental-quick-start.git          # include docs from Bike Rental Demo App
     start_paths: ['docs/*', '!docs/_*', '!docs/axoniq-console-guide']                                 # from every folder in `docs` except those starting with underscore
 
-  - url: https://github.com/AxonIQ/axoniq-playbook.git          # include docs from Bike Rental Demo App
+  - url: https://github.com/AxonIQ/axoniq-playbook.git          # include the playbook
     start_paths: ['docs/*', '!docs/_*']                                 # from every folder in `docs` except those starting with underscore
 
 asciidoc:

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -15,9 +15,13 @@ content:
     start_paths: content/*
     edit_url: https://github.com/AxonIQ/axoniq-library-site/edit/{refname}/{path}
 
-  - url: https://github.com/AxonFramework/AxonFramework.git   # include docs from Axon Framework repo
+  - url: https://github.com/AxonIQ/AxonFramework.git   # include docs from Axon Framework repo
     start_paths: ['docs/*', '!docs/_*']                       # from every folder in `docs` except those starting with underscore
     branches: ['main', 'axon-*', '!axon-{1..3}.*', '!axon-4.{0..9}.x']
+
+  - url: https://github.com/AxonIQ/axoniq-framework.git   # include docs from Axoniq Framework repo
+    start_paths: [ 'docs/*', '!docs/_*' ]                       # from every folder in `docs` except those starting with underscore
+    branches: [ 'main', 'axoniq-*' ]
 
   - url: https://github.com/AxonFramework/extension-amqp.git   # include docs for Axon AMQP Extension repo 
     start_paths: ['docs/*', '!docs/_*']                        # from every folder in `docs` except those starting with underscore
@@ -91,6 +95,7 @@ asciidoc:
     page-pagination: true
     kroki-server-url: http://localhost:8000
     kroki-fetch-diagram: true
+    advanced-framework: true
   extensions:
   - asciidoctor-kroki
   - '@asciidoctor/tabs'


### PR DESCRIPTION
This PR includes the AxoniqFramework documentation sources to the library build, to allow a unified framework documentation build for the axon-framework-reference antora component that has it's sources distributed in 
* [AxonFramework docs](https://github.com/AxonIQ/AxonFramework), and
* [AxoniqFramework docs](https://github.com/AxonIQ/axoniq-framework)

Both repositories trigger the release workflow in this repo for pushes on main / release-branches, so whenever either of the repos change thedocumentation is updated, which allows for independent adjustments in both locations. In case there is a documentation change spanning both repositories, be sure to merge the AxoniqFramework repository first, as it's new contents are most likely referenced from the AxonFramework repo and should be present when the doc changes in AxonFramework depending on AxoniqFramework content are going to a branch that gets published.

This should not be merged before
* https://github.com/AxonIQ/AxonFramework/pull/4420 and
* https://github.com/AxonIQ/axoniq-framework/pull/47
are merged to main to make sure a working documentation version of both is in main and keep the published `development` version of the framework documentation working all the time.