### PR TITLE
[#104] Drop Synapse from Axoniq Docs

### DIFF
--- a/content/home/modules/ROOT/nav.adoc
+++ b/content/home/modules/ROOT/nav.adoc
@@ -7,5 +7,4 @@
 * xref:reference.adoc[]
 ** xref:axon-framework-reference:ROOT:index.adoc[Axon Framework]
 ** xref:axon-server-reference:ROOT:index.adoc[Axon Server]
-** xref:synapse-reference:ROOT:index.adoc[Axon Synapse]
 ** xref:axoniq-platform-reference:ROOT:index.adoc[Axoniq Platform]

--- a/localLinks/update.sh
+++ b/localLinks/update.sh
@@ -29,7 +29,6 @@ cloneOrPullMaster "extension-springcloud" "https://github.com/AxonFramework/exte
 cloneOrPullMaster "extension-tracing" "https://github.com/AxonFramework/extension-tracing.git" "axon-tracing-4.11.x"
 cloneOrPullMaster "axon-server" "https://github.com/AxonIQ/axon-server.git" "axonserver-ee-2024.1.x"
 cloneOrPullMaster "axon-server-image-build" "https://github.com/AxonIQ/axon-server-image-build.git" "main"
-cloneOrPullMaster "axon-synapse" "https://github.com/AxonIQ/axon-synapse.git" "synapse-0.11"
 cloneOrPullMaster "axoniq-platform" "https://github.com/AxonIQ/axoniq-platform.git" "main"
 cloneOrPullMaster "bike-rental-quick-start" "https://github.com/AxonIQ/bike-rental-quick-start.git" "main"
 cloneOrPullMaster "axoniq-playbook" "https://github.com/AxonIQ/axoniq-playbook.git" "main"

--- a/playbook-dev-ui.yaml
+++ b/playbook-dev-ui.yaml
@@ -55,10 +55,6 @@ content:
     start_paths: ['docs/*', '!docs/_*']        # from every folder in `docs` except those starting with underscore
     # branches: [master, 'axonserver-ee-20*'] # and from the specified branches
 
-  - url: ./localLinks/axon-synapse/            # include docs from Axon Synapse repo
-    start_paths: ['docs/*', '!docs/_*']       # from every folder in `docs` except those starting with underscore
-    # branches: [development, 'synapse-*']      # and from the specified branches
-
   - url: ./localLinks/axoniq-platform/           # include docs from AxonIQ Console
     start_paths: ['docs/*', '!docs/_*']       # from every folder in `docs` except those starting with underscore
     # branches: [master, docs]

--- a/playbook-dev.yaml
+++ b/playbook-dev.yaml
@@ -59,10 +59,6 @@ content:
     start_paths: ['docs/*', '!docs/_*']        # from every folder in `docs` except those starting with underscore
     # branches: [master, 'axonserver-ee-20*'] # and from the specified branches
 
-  - url: ./localLinks/axon-synapse/            # include docs from Axon Synapse repo
-    start_paths: ['docs/*', '!docs/_*']       # from every folder in `docs` except those starting with underscore
-    # branches: [development, 'synapse-*']      # and from the specified branches
-
   - url: ./localLinks/axoniq-platform/           # include docs from AxonIQ Console
     start_paths: ['docs/*', '!docs/_*']       # from every folder in `docs` except those starting with underscore
     # branches: [master, docs]

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -75,10 +75,6 @@ content:
     start_paths: ['docs/*', '!docs/_*']                        # from every folder in `docs` except those starting with underscore
 #    branches: [main]                                          # and from the specified branches
 
-  - url: https://github.com/AxonIQ/axon-synapse.git           # include docs from Axon Synapse repo
-    start_paths: ['docs/*', '!docs/_*']                       # from every folder in `docs` except those starting with underscore
-    branches: ['synapse-*']                           # and from the specified branches
-
   - url: https://github.com/AxonIQ/axoniq-platform.git            # include docs from AxonIQ Console
     start_paths: ['docs/*', '!docs/_*']                       # from every folder in `docs` except those starting with underscore
     branches: [main]


### PR DESCRIPTION
With the integration of synapse into Axon Server the documentation on Synapse can be dropped from the library entirely.

resolves #104 