### PR TITLE
[#107] Drop the AF4 getting started from Axoniq Docs

### DIFF
--- a/content/home/modules/ROOT/pages/index.adoc
+++ b/content/home/modules/ROOT/pages/index.adoc
@@ -18,10 +18,6 @@ Basics offer examples on how to use AxonIQ products to complete routine tasks wh
 The xref:home:ROOT:basics.adoc[] page contains all such materials. Some of the most popular ones are:
 
 * link:https://docs.axoniq.io/axon-framework-5-getting-started/[*New!* Getting Started with Axon Framework 5 & Dynamic Consistency Boundary]
-* xref:bikerental-demo:ROOT:index.adoc[]
-// * xref:axoniq-console-getting-started:ROOT:index.adoc[]
-// * xref:af_customization:ROOT:index.adoc[Customizing Axon Framework]
-// * xref:as_admin:ROOT:index.adoc[Axon Server Administration]
 
 == Guides
 

--- a/localLinks/update.sh
+++ b/localLinks/update.sh
@@ -31,7 +31,6 @@ cloneOrPullMaster "axon-server" "https://github.com/AxonIQ/axon-server.git" "axo
 cloneOrPullMaster "axon-server-image-build" "https://github.com/AxonIQ/axon-server-image-build.git" "main"
 cloneOrPullMaster "axon-synapse" "https://github.com/AxonIQ/axon-synapse.git" "synapse-0.11"
 cloneOrPullMaster "axoniq-platform" "https://github.com/AxonIQ/axoniq-platform.git" "main"
-cloneOrPullMaster "bike-rental-quick-start" "https://github.com/AxonIQ/bike-rental-quick-start.git" "main"
 cloneOrPullMaster "axoniq-playbook" "https://github.com/AxonIQ/axoniq-playbook.git" "main"
 
 echo "You should be up-to-date now!"

--- a/playbook-dev-ui.yaml
+++ b/playbook-dev-ui.yaml
@@ -63,9 +63,6 @@ content:
     start_paths: ['docs/*', '!docs/_*']       # from every folder in `docs` except those starting with underscore
     # branches: [master, docs]
 
-  - url: ./localLinks/bike-rental-quick-start/ # include docs from BikeRental Demo app
-    start_paths: ['docs/*', '!docs/_*']        # from every folder in `docs` except those starting with underscore
-
   - url: ./localLinks/axoniq-playbook/ # include docs from BikeRental Demo app
     start_paths: [ 'docs/*', '!docs/_*' ]        # from every folder in `docs` except those starting with underscore
 

--- a/playbook-dev.yaml
+++ b/playbook-dev.yaml
@@ -67,9 +67,6 @@ content:
     start_paths: ['docs/*', '!docs/_*']       # from every folder in `docs` except those starting with underscore
     # branches: [master, docs]
 
-  - url: ./localLinks/bike-rental-quick-start/ # include docs from BikeRental Demo app
-    start_paths: ['docs/*', '!docs/_*']        # from every folder in `docs` except those starting with underscore
-
   - url: ./localLinks/axoniq-playbook/ # include docs from BikeRental Demo app
     start_paths: [ 'docs/*', '!docs/_*' ]        # from every folder in `docs` except those starting with underscore
 

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -83,9 +83,6 @@ content:
     start_paths: ['docs/*', '!docs/_*']                       # from every folder in `docs` except those starting with underscore
     branches: [main]
         
-  - url: https://github.com/AxonIQ/bike-rental-quick-start.git          # include docs from Bike Rental Demo App
-    start_paths: ['docs/*', '!docs/_*', '!docs/axoniq-console-guide']                                 # from every folder in `docs` except those starting with underscore
-
   - url: https://github.com/AxonIQ/axoniq-playbook.git          # include the playbook
     start_paths: ['docs/*', '!docs/_*']                                 # from every folder in `docs` except those starting with underscore
 


### PR DESCRIPTION
With the move to AF5 and retirement of AF4 in June, we remove the AF4 getting started guide from the documentation site.

resolves #107 