### PR TITLE
Include Workflows documentation in the library-site

### DIFF
--- a/content/home/modules/ROOT/pages/index.adoc
+++ b/content/home/modules/ROOT/pages/index.adoc
@@ -17,7 +17,8 @@ Basics offer examples on how to use AxonIQ products to complete routine tasks wh
 
 The xref:home:ROOT:basics.adoc[] page contains all such materials. Some of the most popular ones are:
 
-* link:https://docs.axoniq.io/axon-framework-5-getting-started/[*New!* Getting Started with Axon Framework 5 & Dynamic Consistency Boundary]
+* xref:axon-workflow-getting-started::index.adoc[*New!* Getting Started with Axoniq's Workflow Engine]
+* xref:axon-framework-5-getting-started::index.adoc[Getting Started with Axon Framework 5 & Dynamic Consistency Boundary]
 
 == Guides
 

--- a/localLinks/update.sh
+++ b/localLinks/update.sh
@@ -16,6 +16,7 @@ cloneOrPullMaster () {
 # Axon Framework has two branches: master and 4.10.x
 cloneOrPullMaster "AxonFramework" "https://github.com/AxonIQ/AxonFramework.git" "main"
 cloneOrPullMaster "AxoniqFramework" "https://github.com/AxonIQ/axoniq-framework.git" "main"
+cloneOrPullMaster "extension-workflow" "https://github.com/AxonIQ/extension-workflow.git" "main"
 cloneOrPullMaster "extension-amqp" "https://github.com/AxonFramework/extension-amqp.git" "axon-amqp-4.11.x"
 cloneOrPullMaster "extension-jgroups" "https://github.com/AxonFramework/extension-jgroups.git" "axon-jgroups-4.11.x"
 cloneOrPullMaster "extension-jobrunrpro" "https://github.com/AxonFramework/extension-jobrunrpro.git" "axon-jobrunrpro-4.11.x"

--- a/playbook-dev-ui.yaml
+++ b/playbook-dev-ui.yaml
@@ -14,6 +14,9 @@ content:
   - url: ./localLinks/AxoniqFramework/          # include docs from Axon Framework repo
     start_paths: [ 'docs/*', '!docs/_*', '!docs/reference/*' ]       # from every folder in `docs` except those starting with underscore
 
+  - url: ./localLinks/extension-workflow/      # include docs from extension-workflow repo
+    start_paths: [ 'docs/*', '!docs/_*' ]      # from every folder in `docs` except those starting with underscore
+
   - url: ./localLinks/extension-amqp/          # include docs from Axon AMQP Extension repo
     start_paths: ['docs/*', '!docs/_*']        # from every folder in `docs` except those starting with underscore
 
@@ -68,6 +71,7 @@ asciidoc:
     page-pagination: true
     kroki-fetch-diagram: false
     advanced-framework: true
+    workflows: true
   extensions:
   - asciidoctor-kroki
   - '@asciidoctor/tabs'

--- a/playbook-dev.yaml
+++ b/playbook-dev.yaml
@@ -18,6 +18,9 @@ content:
   - url: ./localLinks/AxoniqFramework/          # include docs from Axon Framework repo
     start_paths: [ 'docs/*', '!docs/_*', '!docs/reference/*' ]       # from every folder in `docs` except those starting with underscore
 
+  - url: ./localLinks/extension-workflow/      # include docs from extension-workflow repo
+    start_paths: [ 'docs/*', '!docs/_*' ]      # from every folder in `docs` except those starting with underscore
+
   - url: ./localLinks/extension-amqp/          # include docs from Axon AMQP Extension repo
     start_paths: ['docs/*', '!docs/_*']        # from every folder in `docs` except those starting with underscore
 
@@ -73,6 +76,7 @@ asciidoc:
     kroki-server-url: http://localhost:8000
     kroki-fetch-diagram: true
     advanced-framework: true
+    workflows: true
   extensions:
   - asciidoctor-kroki
   - '@asciidoctor/tabs'
@@ -101,4 +105,4 @@ runtime:
 
 ui:
   bundle:
-    url: https://github.com/AxonIQ/axoniq-library-ui/releases/download/v.1.0.2/ui-bundle.zip
+    url: https://github.com/AxonIQ/axoniq-library-ui/releases/download/v.1.0.3/ui-bundle.zip

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -23,43 +23,47 @@ content:
     start_paths: [ 'docs/*', '!docs/_*' ]                       # from every folder in `docs` except those starting with underscore
     branches: [ 'main', 'axoniq-*' ]
 
-  - url: https://github.com/AxonFramework/extension-amqp.git   # include docs for Axon AMQP Extension repo 
+  - url: https://github.com/AxonIQ/extension-workflow.git  # include docs from extension-workflow repo
+    start_paths: [ 'docs/*', '!docs/_*' ]                  # from every folder in `docs` except those starting with underscore
+    branches: [ 'main' ]
+
+  - url: https://github.com/AxonFramework/extension-amqp.git   # include docs for Axon AMQP Extension repo
     start_paths: ['docs/*', '!docs/_*']                        # from every folder in `docs` except those starting with underscore
     branches: [master, 'axon-amqp-*', '!axon-amqp-4.{0..9}.x']
 
-  - url: https://github.com/AxonFramework/extension-jgroups.git  # include docs for Axon JGroups Extension repo 
+  - url: https://github.com/AxonFramework/extension-jgroups.git  # include docs for Axon JGroups Extension repo
     start_paths: ['docs/*', '!docs/_*']                          # from every folder in `docs` except those starting with underscore
     branches: [master, 'axon-jgroups-*', '!axon-jgroups-4.{0..9}.x']
 
-  - url: https://github.com/AxonFramework/extension-jobrunrpro.git  # include docs for Axon JobRunrPro Extension repo 
+  - url: https://github.com/AxonFramework/extension-jobrunrpro.git  # include docs for Axon JobRunrPro Extension repo
     start_paths: ['docs/*', '!docs/_*']                          # from every folder in `docs` except those starting with underscorej
     branches: [master, 'axon-jobrunrpro-*', '!axon-jobrunrpro-4.{0..9}.x']
 
-  - url: https://github.com/AxonFramework/extension-kafka.git  # include docs for Axon Kafka Extension repo 
+  - url: https://github.com/AxonFramework/extension-kafka.git  # include docs for Axon Kafka Extension repo
     start_paths: ['docs/*', '!docs/_*']                          # from every folder in `docs` except those starting with underscorej
     branches: [master, 'axon-kafka-*', '!axon-kafka-4.{0..9}.x']
 
-  - url: https://github.com/AxonFramework/extension-kotlin.git  # include docs for Axon Kotlin Extension repo 
+  - url: https://github.com/AxonFramework/extension-kotlin.git  # include docs for Axon Kotlin Extension repo
     start_paths: ['docs/*', '!docs/_*']                          # from every folder in `docs` except those starting with underscorej
     branches: [master, 'axon-kotlin-*', '!axon-kotlin-4.{0..9}.x']
 
-  - url: https://github.com/AxonFramework/extension-mongo.git  # include docs for Axon MongoDB Extension repo 
+  - url: https://github.com/AxonFramework/extension-mongo.git  # include docs for Axon MongoDB Extension repo
     start_paths: ['docs/*', '!docs/_*']                          # from every folder in `docs` except those starting with underscorej
     branches: [main, 'axon-mongo-*', '!axon-mongo-4.{0..9}.x']
 
-  - url: https://github.com/AxonFramework/extension-multitenancy.git  # include docs for Axon Multitenancy Extension repo 
+  - url: https://github.com/AxonFramework/extension-multitenancy.git  # include docs for Axon Multitenancy Extension repo
     start_paths: ['docs/*', '!docs/_*']                          # from every folder in `docs` except those starting with underscorej
     branches: [main, 'axon-multitenancy-*', '!axon-multitenancy-4.{0..9}.x']
 
-  - url: https://github.com/AxonFramework/extension-reactor.git  # include docs for Axon Reactor Extension repo 
+  - url: https://github.com/AxonFramework/extension-reactor.git  # include docs for Axon Reactor Extension repo
     start_paths: ['docs/*', '!docs/_*']                          # from every folder in `docs` except those starting with underscorej
     branches: [main, 'axon-reactor-*', '!axon-reactor-4.{0..9}.x']
 
-  - url: https://github.com/AxonFramework/extension-spring-aot.git  # include docs for Axon Spring AOT Extension repo 
+  - url: https://github.com/AxonFramework/extension-spring-aot.git  # include docs for Axon Spring AOT Extension repo
     start_paths: ['docs/*', '!docs/_*']                          # from every folder in `docs` except those starting with underscorej
     branches: [main, 'axon-spring-aot-*', '!axon-spring-aot-4.{0..9}.x']
 
-  - url: https://github.com/AxonFramework/extension-springcloud.git  # include docs for Axon Spring Cloud Extension repo 
+  - url: https://github.com/AxonFramework/extension-springcloud.git  # include docs for Axon Spring Cloud Extension repo
     start_paths: ['docs/*', '!docs/_*']                          # from every folder in `docs` except those starting with underscorej
     branches: [main, 'axon-springcloud-*', '!axon-springcloud-4.{0..9}.x']
 
@@ -78,7 +82,7 @@ content:
   - url: https://github.com/AxonIQ/axoniq-platform.git            # include docs from AxonIQ Console
     start_paths: ['docs/*', '!docs/_*']                       # from every folder in `docs` except those starting with underscore
     branches: [main]
-        
+
   - url: https://github.com/AxonIQ/axoniq-playbook.git          # include the playbook
     start_paths: ['docs/*', '!docs/_*']                                 # from every folder in `docs` except those starting with underscore
 
@@ -89,6 +93,7 @@ asciidoc:
     kroki-server-url: http://localhost:8000
     kroki-fetch-diagram: true
     advanced-framework: true
+    workflows: true
   extensions:
   - asciidoctor-kroki
   - '@asciidoctor/tabs'
@@ -120,4 +125,4 @@ runtime:
 
 ui:
   bundle:
-    url: https://github.com/AxonIQ/axoniq-library-ui/releases/download/v.1.0.2/ui-bundle.zip
+    url: https://github.com/AxonIQ/axoniq-library-ui/releases/download/v.1.0.3/ui-bundle.zip


### PR DESCRIPTION
With the MVP release of workflows we want to include the workflow documentation in the library site.

On the Home-Page, the Workflow getting started guide becomes the "New!" item under Basics.

resolves https://github.com/AxonIQ/extension-workflow/issues/154