### PR TITLE
Include data protection extension reference in the library-site

### DIFF
--- a/localLinks/update.sh
+++ b/localLinks/update.sh
@@ -17,6 +17,7 @@ cloneOrPullMaster () {
 cloneOrPullMaster "AxonFramework" "https://github.com/AxonIQ/AxonFramework.git" "main"
 cloneOrPullMaster "AxoniqFramework" "https://github.com/AxonIQ/axoniq-framework.git" "main"
 cloneOrPullMaster "extension-workflow" "https://github.com/AxonIQ/extension-workflow.git" "main"
+cloneOrPullMaster "extension-data-protection" "https://github.com/AxonIQ/extension-data-protection.git" "main"
 cloneOrPullMaster "extension-amqp" "https://github.com/AxonFramework/extension-amqp.git" "axon-amqp-4.11.x"
 cloneOrPullMaster "extension-jgroups" "https://github.com/AxonFramework/extension-jgroups.git" "axon-jgroups-4.11.x"
 cloneOrPullMaster "extension-jobrunrpro" "https://github.com/AxonFramework/extension-jobrunrpro.git" "axon-jobrunrpro-4.11.x"

--- a/playbook-dev-ui.yaml
+++ b/playbook-dev-ui.yaml
@@ -17,6 +17,9 @@ content:
   - url: ./localLinks/extension-workflow/      # include docs from extension-workflow repo
     start_paths: [ 'docs/*', '!docs/_*' ]      # from every folder in `docs` except those starting with underscore
 
+  - url: ./localLinks/extension-data-protection/   # include docs from Axoniq Data Protection repo
+    start_paths: [ 'docs/*', '!docs/_*' ]            # from every folder in `docs` except those starting with underscore
+
   - url: ./localLinks/extension-amqp/          # include docs from Axon AMQP Extension repo
     start_paths: ['docs/*', '!docs/_*']        # from every folder in `docs` except those starting with underscore
 
@@ -72,6 +75,7 @@ asciidoc:
     kroki-fetch-diagram: false
     advanced-framework: true
     workflows: true
+    data-protection: true
   extensions:
   - asciidoctor-kroki
   - '@asciidoctor/tabs'

--- a/playbook-dev.yaml
+++ b/playbook-dev.yaml
@@ -21,6 +21,9 @@ content:
   - url: ./localLinks/extension-workflow/      # include docs from extension-workflow repo
     start_paths: [ 'docs/*', '!docs/_*' ]      # from every folder in `docs` except those starting with underscore
 
+  - url: ./localLinks/extension-data-protection/   # include docs from Axoniq Data Protection repo
+    start_paths: [ 'docs/*', '!docs/_*' ]            # from every folder in `docs` except those starting with underscore
+
   - url: ./localLinks/extension-amqp/          # include docs from Axon AMQP Extension repo
     start_paths: ['docs/*', '!docs/_*']        # from every folder in `docs` except those starting with underscore
 
@@ -77,6 +80,7 @@ asciidoc:
     kroki-fetch-diagram: true
     advanced-framework: true
     workflows: true
+    data-protection: true
   extensions:
   - asciidoctor-kroki
   - '@asciidoctor/tabs'

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -27,6 +27,10 @@ content:
     start_paths: [ 'docs/*', '!docs/_*' ]                  # from every folder in `docs` except those starting with underscore
     branches: [ 'main' ]
 
+  - url: https://github.com/AxonIQ/extension-data-protection.git   # include docs for Axoniq Data Protection repo
+    start_paths: [ 'docs/*', '!docs/_*' ]                          # from every folder in `docs` except those starting with underscore
+    branches: [ 'main', 'axoniq-data-protection-*' ]
+
   - url: https://github.com/AxonFramework/extension-amqp.git   # include docs for Axon AMQP Extension repo
     start_paths: ['docs/*', '!docs/_*']                        # from every folder in `docs` except those starting with underscore
     branches: [master, 'axon-amqp-*', '!axon-amqp-4.{0..9}.x']
@@ -94,6 +98,7 @@ asciidoc:
     kroki-fetch-diagram: true
     advanced-framework: true
     workflows: true
+    data-protection: true
   extensions:
   - asciidoctor-kroki
   - '@asciidoctor/tabs'


### PR DESCRIPTION
The data protection extension reference guide should appear as part of the framework reference guide. This commit includes the dataprotection extension github repo in the main playbook and playbooks for local dev builds.

should be merged after https://github.com/AxonIQ/extension-data-protection/pull/17 

resolves https://github.com/AxonIQ/extension-data-protection/issues/16