### PR TITLE
Reorganize workflows documentation

### DIFF
--- a/playbook.yaml
+++ b/playbook.yaml
@@ -25,7 +25,7 @@ content:
 
   - url: https://github.com/AxonIQ/extension-workflow.git  # include docs from extension-workflow repo
     start_paths: [ 'docs/*', '!docs/_*' ]                  # from every folder in `docs` except those starting with underscore
-    branches: [ 'main' ]
+    branches: [ 'axoniq-workflow-*' ]
 
   - url: https://github.com/AxonIQ/extension-data-protection.git   # include docs for Axoniq Data Protection repo
     start_paths: [ 'docs/*', '!docs/_*' ]                          # from every folder in `docs` except those starting with underscore


### PR DESCRIPTION
To avoid unpublished api changes to be present in the workflows reference or getting started guide, we only publish documentation from the workflows release branch for now.