### PR TITLE
Refer to "Axon Framework and Axoniq Framework" comparison page

### DIFF
--- a/content/home/modules/ROOT/pages/index.adoc
+++ b/content/home/modules/ROOT/pages/index.adoc
@@ -34,4 +34,4 @@ The xref:home:ROOT:reference.adoc[] page contains all such materials. Some of th
 * xref:axon-framework-reference:ROOT:index.adoc[Axon Framework Reference Guide]
 * xref:axon-server-reference:ROOT:index.adoc[Axon Server Reference Guide]
 * xref:axoniq-platform-reference:ROOT:index.adoc[Axoniq Platform Reference Guide]
-* xref:axon-framework-reference:framework-comparison.adoc[Axon Framework and Axoniq Framework Comparison]
+* xref:axon-framework-reference:framework-comparison:index.adoc[Axon Framework and Axoniq Framework Comparison]

--- a/content/home/modules/ROOT/pages/index.adoc
+++ b/content/home/modules/ROOT/pages/index.adoc
@@ -34,4 +34,4 @@ The xref:home:ROOT:reference.adoc[] page contains all such materials. Some of th
 * xref:axon-framework-reference:ROOT:index.adoc[Axon Framework Reference Guide]
 * xref:axon-server-reference:ROOT:index.adoc[Axon Server Reference Guide]
 * xref:axoniq-platform-reference:ROOT:index.adoc[Axoniq Platform Reference Guide]
-// * xref:axoniq_cloud_ref:ROOT:index.adoc[]
+* xref:axon-framework-reference:framework-comparison.adoc[Axon Framework and Axoniq Framework Comparison]


### PR DESCRIPTION
This pull request adds a reference to the [Axon Framework and Axoniq Framework](https://docs.axoniq.io/axon-framework-reference/5.2/framework-comparison/) page, directly on the home page of Axoniq Docs.
This is done per user request, as people have difficulty finding the page.