### PR TITLE
mention the terraform kubernetes module in the installation guide

### DIFF
--- a/content/axon-server-installation-guides/modules/ROOT/pages/developer/kubernetes.adoc
+++ b/content/axon-server-installation-guides/modules/ROOT/pages/developer/kubernetes.adoc
@@ -9,6 +9,11 @@ AxonIQ does not provide a HELM chart, nor any installation instructions for serv
 You can adapt the instruction in this guide for your specific situation.
 ====
 
+[TIP]
+====
+If you prefer to automate the setup below, AxonIQ maintains a https://github.com/AxonIQ/terraform-axonserver-k8s[Terraform module,role=external,window=_blank] to deploy Axon Server on Kubernetes, including single-node deployments.
+====
+
 == Overview
 
 The Kubernetes setup works with a variety of individual parts:

--- a/content/axon-server-installation-guides/modules/ROOT/pages/enterprise/kubernetes.adoc
+++ b/content/axon-server-installation-guides/modules/ROOT/pages/enterprise/kubernetes.adoc
@@ -10,6 +10,11 @@ AxonIQ does not provide a HELM chart, nor any installation instructions for serv
 You can adapt the instruction in this guide for your specific situation.
 ====
 
+[TIP]
+====
+If you prefer to automate the setup below, AxonIQ maintains a https://github.com/AxonIQ/terraform-axonserver-k8s[Terraform module,role=external,window=_blank] to deploy Axon Server on Kubernetes, including multi-node clusters using a license file or an AxonIQ Console access token.
+====
+
 == Overview
 
 The Kubernetes setup works with a variety of individual parts:

--- a/content/axon-server-installation-guides/modules/ROOT/pages/professional/kubernetes.adoc
+++ b/content/axon-server-installation-guides/modules/ROOT/pages/professional/kubernetes.adoc
@@ -10,6 +10,11 @@ AxonIQ does not provide a HELM chart, nor any installation instructions for serv
 You can adapt the instruction in this guide for your specific situation.
 ====
 
+[TIP]
+====
+If you prefer to automate the setup below, AxonIQ maintains a https://github.com/AxonIQ/terraform-axonserver-k8s[Terraform module,role=external,window=_blank] to deploy Axon Server on Kubernetes, including multi-node clusters using an AxonIQ Console access token.
+====
+
 == Overview
 
 The Kubernetes setup works with a variety of individual parts:


### PR DESCRIPTION
## Summary
- Add a TIP admonition to the developer, professional, and enterprise Kubernetes installation pages pointing readers to https://github.com/AxonIQ/terraform-axonserver-k8s as an automated alternative to the manual setup steps in each guide.
- Related to AxonIQ/axon-server#2358, which adds the same mention to the axon-server-reference Docker/Kubernetes installation page.

## Test plan
- [x] Rebuilt the docs locally (`npx antora playbook-dev.yaml`); the TIP renders correctly on all three pages with no new errors.